### PR TITLE
Замена py.test на pytest в run_tests, так как pytest 7.2.0 больше не зависит от py

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -4,7 +4,7 @@ import shared
 
 def main():
     shared.configure_python_path()
-    subprocess.check_call(["python", "-m", "py.test", "-vv", "-s", shared.TESTS])
+    subprocess.check_call(["python", "-m", "pytest", "-vv", "-s", shared.TESTS])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Из [списка изменений](https://docs.pytest.org/en/7.2.x/changelog.html) в pytest 7.2.0 (2022-10-23):

> [#10396](https://github.com/pytest-dev/pytest/issues/10396): `pytest` no longer depends on the `py` library. `pytest` provides a vendored copy of `py.error` and `py.path` modules but will use the `py` library if it is installed. If you need other `py.*` modules, continue to install the deprecated `py` library separately, otherwise it can usually be removed as a dependency.

В связи с этим в [`run_tests.py`](https://github.com/JetBrains-Research/formal-lang-course/compare/main...IlyaMuravjov:formal-lang-course:run-tests-fix?expand=1#diff-c8ebeae9a0d4391625d71641d1977a6d178be8257ff4bea7ef9f4862480401c4) `py.test` был заменён на `pytest`. Если этого не сделать, то тесты без явной установки устаревшей библиотеки `py` (в том в числе если настроить их запуск через GitHub Actions) будут падать с ошибкой:

> `/opt/hostedtoolcache/Python/3.8.14/x64/bin/python: Error while finding module specification for 'py.test' (ModuleNotFoundError: __path__ attribute not found on 'py' while trying to find 'py.test')`
